### PR TITLE
update digestmod to sha256

### DIFF
--- a/oauth2_proxy_cookie.py
+++ b/oauth2_proxy_cookie.py
@@ -62,7 +62,7 @@ class Validator(object):
         return value, cookie_date
 
     def sign(self, *args):
-        h = hmac.new(self.secret, digestmod=hashlib.sha1)
+        h = hmac.new(self.secret, digestmod=hashlib.sha256)
         for arg in args:
             h.update(arg.encode())
         return h.digest()

--- a/test_oauth2_proxy_cookie.py
+++ b/test_oauth2_proxy_cookie.py
@@ -8,9 +8,9 @@ from oauth2_proxy_cookie import Validator, InvalidCookie, InvalidSignature, Expi
 COOKIE_DATE = datetime(2017, 1, 1, 6, 0, 0)
 
 EXPIRATION = timedelta(hours=1)
-VALID_COOKIE = 'Zm9vQGJhcg==|1483250400|7_TbBXD14iv4kEh5wPWzTdTe0Oo='
-INVALID_COOKIE = 'AAAA|1483250400|7_TbBXD14iv4kEh5wPWzTdTe0Oo='
-EXPIRED_COOKIE = 'Zm9vQGJhcg==|1483254000|lCSWqvfyJY_QP8boDfT3mwEl3GI='
+VALID_COOKIE = 'Zm9vQGJhcg==|1483250400|WW3isJGM26B1RCA2fxVnI0c88nzEdPmt5Yjs8I7Y6DE='
+INVALID_COOKIE = 'AAAA|1483250400|WW3isJGM26B1RCA2fxVnI0c88nzEdPmt5Yjs8I7Y6DE='
+EXPIRED_COOKIE = 'Zm9vQGJhcg==|1483254000|1d7LggzEsqWNe3KWNb7Tv3VIZhcc3WMKJ6YgPQ13Das='
 
 
 class OAuth2ProxyCookieTest(unittest.TestCase):


### PR DESCRIPTION
Hi,

The objective of this PR is to update the digest mode from sha1 to sha256

The cipher has recently been updated from sha1 to sha256 in the oauth2-proxy project, breaking the signature validation in oauth2-proxy-cookie.

Link:
https://github.com/oauth2-proxy/oauth2-proxy/blob/dd361389659e5da81f1ca51051966d4fe15260ab/pkg/encryption/utils.go#L67